### PR TITLE
Build AARCH64 Image

### DIFF
--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -13,7 +13,7 @@ set -e
 app=${1}
 registry=${2}
 
-platform="linux/amd64,linux/arm/v7"
+platform="linux/amd64,linux/arm/v7,linux/arm64/v8"
 dockerfile=docker/${app}/Dockerfile
 context=$(echo -n ${dockerfile} | rev | cut -f2- -d'/' | rev)
 


### PR DESCRIPTION
Update GitHub workflow so that it also builds AARCH64 image for 64bit
OSes used on RPi 3/4.