### PR TITLE
Custom templates

### DIFF
--- a/custom/README.md
+++ b/custom/README.md
@@ -1,7 +1,6 @@
 # Custom Templates
-This directory contains custom docker-compose files, that use the Docker Images created by prind but not the actual `docker-compose.yaml` of prind.  
-  
-These files are geared towards more experienced users and aim to provide a starting point for more complex setups. Documentation from the main Readme does only apply partially or not at all.
-Docker and Docker Compose knowledge is strongly recommended as Support for these custom configurations is limited.  
+This directory contains custom docker-compose files, that use the Docker Images created by prind.  
+
+These files are not part of prind and are geared towards more experienced users. Their aim is to provide a starting point for more complex setups. Documentation from the main README does not apply. Docker and Docker Compose knowledge is strongly recommended as Support for these configurations is limited.  
   
 Comments at the beginning of each file describe the usecase and necessary steps to get them to work.

--- a/custom/README.md
+++ b/custom/README.md
@@ -1,0 +1,7 @@
+# Custom Templates
+This directory contains custom docker-compose files, that use the Docker Images created by prind but not the actual `docker-compose.yaml` of prind.  
+  
+These files are geared towards more experienced users and aim to provide a starting point for more complex setups. Documentation from the main Readme does only apply partially or not at all.
+Docker and Docker Compose knowledge is strongly recommended as Support for these custom configurations is limited.  
+  
+Comments at the beginning of each file describe the usecase and necessary steps to get them to work.

--- a/custom/docker-compose.custom.multiple-printers.yaml
+++ b/custom/docker-compose.custom.multiple-printers.yaml
@@ -9,7 +9,7 @@
 ## About this setup:
 ## * Moonraker services for each printer are available via their unique port (8101 and 8201 in this example).
 ## * Webcam services for each printer are available via their unique port (8102 and 8202 in this example)
-## * Fluidd is accessible via 80
+## * Fluidd is used as Web frontend and is accessible via 80
 ## * You'll have to add your printers manually to fluidd via their moonraker ports eg. http://dockerhost:8101 and http://dockerhost:8201
 ##
 ## Setup:

--- a/custom/docker-compose.custom.multiple-printers.yaml
+++ b/custom/docker-compose.custom.multiple-printers.yaml
@@ -1,0 +1,109 @@
+## Usecase: Run multiple Printers on the same Host
+##
+## Assumptions: 
+## * I have two printers
+## * One is called printer1, the other one printer2
+## * printer1 is using serial port /dev/ttyUSB0 and webcam /dev/video0
+## * printer2 is using serial port /dev/ttyUSB1 and webcam /dev/video1
+##
+## About this setup:
+## * Moonraker services for each printer are available via their unique port (8101 and 8201 in this example).
+## * Webcam services for each printer are available via their unique port (8102 and 8202 in this example)
+## * Fluidd is accessible via 80
+## * You'll have to add your printers manually to fluidd via their moonraker ports eg. http://dockerhost:8101 and http://dockerhost:8201
+##
+## Setup:
+## 1. Check out prind and enter the repository
+##      > git clone https://github.com/mkuf/prind/
+##      > cd prind
+## 2. Create config files for each printer and set permissions
+##      > for i in printer1 printer2; do cp config/printer.cfg config/${i}.cfg; cp config/moonraker.conf config/${i}.moonraker.conf
+##      > chown -R 1000:1000 config
+## 3. Copy this file to the root of the repository, overwriting the original docker-compose.yaml
+##      > cp custom/docker-compose.custom.multiple-printers.yaml docker-compose.yaml
+## 4. For each printer create a klipper, moonraker and webcam service as shown below
+## 5. Make sure each service has a unique 'command' and is referencing the files created by 2.
+## 6. Add your printers config to their corresponding file
+## 7. Set the correct klippy_uds_address in the corresponding *.moonraker.conf
+## 8. Update the Devices used for klipper and the webcam services
+## 9. Start the stack
+##      > docker compose up -d
+
+## Common Templates
+x-klipper-svc: &klipper-svc
+  image: mkuf/klipper:latest
+  restart: unless-stopped
+  volumes:
+    - ./config:/opt/printer_data/config
+    - run:/opt/printer_data/run
+    - gcode:/opt/printer_data/gcodes
+    - log:/opt/printer_data/logs
+
+x-moonraker-svc: &moonraker-svc
+  image: mkuf/moonraker:latest
+  restart: unless-stopped
+  volumes:
+    - /dev/null:/opt/klipper/config/null
+    - /dev/null:/opt/klipper/docs/null
+    - ./config:/opt/printer_data/config
+    - run:/opt/printer_data/run
+    - gcode:/opt/printer_data/gcodes
+    - log:/opt/printer_data/logs
+
+x-ustreamer-svc: &ustreamer-svc
+  image: mkuf/ustreamer:latest
+  restart: unless-stopped
+  command: --host=0.0.0.0 --port=8080 --slowdown --device=/dev/webcam --resolution=1280x960 --format=MJPEG --desired-fps=30
+
+## Service Definitions
+services:
+
+  ## Printer1
+  ## Access api via port 8101/tcp and webcam via 8102/tcp
+  printer1-klipper:
+    <<: *klipper-svc
+    command: -I printer_data/run/printer1.klipper.tty -a printer_data/run/printer1.klipper.sock printer_data/config/printer1.cfg -l printer_data/logs/printer1.klippy.log
+    devices:
+      - /dev/ttyUSB0:/dev/ttyUSB0
+  printer1-moonraker:
+    <<: *moonraker-svc
+    command: -d printer_data -c printer_data/config/printer1.moonraker.conf -l printer_data/logs/printer1.moonraker.log
+    ports:
+      - 8101:7125
+  printer1-webcam:
+    <<: *ustreamer-svc
+    devices:
+      - /dev/video0:/dev/webcam
+    ports:
+      - 8102:8080
+
+  ## Printer2
+  ## Access api via port 8201/tcp and webcam via 8202/tcp
+  printer2-klipper:
+    <<: *klipper-svc
+    command: -I printer_data/run/printer2.klipper.tty -a printer_data/run/printer2.klipper.sock printer_data/config/printer2.cfg -l printer_data/logs/printer2.klippy.log
+    devices:
+      - /dev/ttyUSB1:/dev/ttyUSB1
+  printer2-moonraker:
+    <<: *moonraker-svc
+    command: -d printer_data -c printer_data/config/printer2.moonraker.conf -l printer_data/logs/printer2.moonraker.log
+    ports:
+      - 8201:7125
+  printer2-webcam:
+    <<: *ustreamer-svc
+    devices:
+      - /dev/video1:/dev/webcam
+    ports:
+      - 8202:8080
+
+  ## Use Fluidd as Frontend
+  fluidd:
+    image: cadriel/fluidd:latest
+    restart: unless-stopped
+    ports:
+      - 80:80
+
+volumes:
+  run:
+  gcode:
+  log:

--- a/custom/docker-compose.custom.multiple-printers.yaml
+++ b/custom/docker-compose.custom.multiple-printers.yaml
@@ -17,7 +17,7 @@
 ##      > git clone https://github.com/mkuf/prind/
 ##      > cd prind
 ## 2. Create config files for each printer and set permissions
-##      > for i in printer1 printer2; do cp config/printer.cfg config/${i}.cfg; cp config/moonraker.conf config/${i}.moonraker.conf
+##      > for i in printer1 printer2; do cp config/printer.cfg config/${i}.cfg; cp config/moonraker.conf config/${i}.moonraker.conf; done
 ##      > chown -R 1000:1000 config
 ## 3. Copy this file to the root of the repository, overwriting the original docker-compose.yaml
 ##      > cp custom/docker-compose.custom.multiple-printers.yaml docker-compose.yaml

--- a/custom/docker-compose.custom.portainer.yaml
+++ b/custom/docker-compose.custom.portainer.yaml
@@ -1,0 +1,97 @@
+## Usecase: Minimal Configuration to be used with Portainer
+## Issue: https://github.com/mkuf/prind/issues/39
+##
+## Setup:
+## 1. Check out prind to a permanent directory
+##      > git clone https://github.com/mkuf/prind/ /data/prind
+## 2. Change permissions for the prind directory
+##      > chown -R 1000:1000 /data/prind
+## 3. Set the device for klipper to your printers serial port
+## 4. Upload this file to portainer
+
+services:
+  klipper:
+    image: mkuf/klipper:latest
+    restart: unless-stopped
+    logging:
+      driver: none
+    depends_on:
+      init:
+        condition: service_completed_successfully
+    command: -I printer_data/run/klipper.tty -a printer_data/run/klipper.sock printer_data/config/printer.cfg -l printer_data/logs/klippy.log
+    devices:
+      - /dev/ttyUSB0:/dev/ttyUSB0
+    volumes:
+      - /data/prind/config:/opt/printer_data/config
+      - run:/opt/printer_data/run
+      - gcode:/opt/printer_data/gcodes
+      - log:/opt/printer_data/logs
+
+  moonraker:
+    image: mkuf/moonraker:latest
+    restart: unless-stopped
+    pid: host
+    logging:
+      driver: none
+    depends_on:
+      init:
+        condition: service_completed_successfully
+      klipper:
+        condition: service_started
+    volumes:
+      - /dev/null:/opt/klipper/config/null
+      - /dev/null:/opt/klipper/docs/null
+      - /run/dbus:/run/dbus
+      - /run/systemd:/run/systemd
+      - run:/opt/printer_data/run
+      - gcode:/opt/printer_data/gcodes
+      - log:/opt/printer_data/logs
+      - moonraker-db:/opt/printer_data/database
+      - /data/prind/config:/opt/printer_data/config
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.services.moonraker.loadbalancer.server.port=7125"
+      - "traefik.http.routers.moonraker.rule=PathPrefix(`/websocket`,`/printer`,`/api`,`/access`,`/machine`,`/server`)"
+      - "traefik.http.routers.moonraker.entrypoints=web"
+
+  fluidd:
+    image: cadriel/fluidd:latest
+    restart: unless-stopped
+    profiles:
+      - fluidd
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.services.fluidd.loadbalancer.server.port=80"
+      - "traefik.http.routers.fluidd.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.fluidd.entrypoints=web"
+
+  init:
+    image: busybox:latest
+    command: chown -R 1000:1000 /prind/config
+    volumes:
+      - /data/prind:/prind
+
+  traefik:
+    image: traefik:v2.5
+    command:
+      - "--accesslog"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+    ports:
+      - "80:80"
+    restart: unless-stopped
+    volumes:
+        - "/var/run/docker.sock:/var/run/docker.sock:ro"
+
+volumes:
+  run:
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+  gcode:
+  moonraker-db:
+  log:
+    driver_opts:
+      type: tmpfs
+      device: tmpfs

--- a/custom/docker-compose.custom.portainer.yaml
+++ b/custom/docker-compose.custom.portainer.yaml
@@ -1,12 +1,22 @@
 ## Usecase: Minimal Configuration to be used with Portainer
 ## Issue: https://github.com/mkuf/prind/issues/39
 ##
+## Assumptions:
+## * I want to manage my printers software via portainer
+## * I have shell access to the host running portainer
+## * My printers Serial port is /dev/ttyUSB0
+## * My printers Webcam device is /dev/video0
+##
+## About this setup:
+## * traefik is used as proxy for the web frontend, moonraker and the webcam service
+## * fluidd is used as frontend
+##
 ## Setup:
 ## 1. Check out prind to a permanent directory
 ##      > git clone https://github.com/mkuf/prind/ /data/prind
 ## 2. Change permissions for the prind directory
 ##      > chown -R 1000:1000 /data/prind
-## 3. Set the device for klipper to your printers serial port
+## 3. Update the Devices used for klipper and the webcam service
 ## 4. Upload this file to portainer
 
 services:
@@ -53,6 +63,20 @@ services:
       - "traefik.http.services.moonraker.loadbalancer.server.port=7125"
       - "traefik.http.routers.moonraker.rule=PathPrefix(`/websocket`,`/printer`,`/api`,`/access`,`/machine`,`/server`)"
       - "traefik.http.routers.moonraker.entrypoints=web"
+
+  webcam:
+    image: mkuf/ustreamer:latest
+    restart: unless-stopped
+    command: --host=0.0.0.0 --port=8080 --slowdown --device=/dev/webcam --resolution=1280x960 --format=MJPEG --desired-fps=30
+    devices:
+      - /dev/video0:/dev/webcam
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.services.webcam.loadbalancer.server.port=8080"
+      - "traefik.http.routers.webcam.rule=PathPrefix(`/webcam`)"
+      - "traefik.http.routers.webcam.entrypoints=web"
+      - "traefik.http.middlewares.webcam.stripprefix.prefixes=/webcam"
+      - "traefik.http.routers.webcam.middlewares=webcam"
 
   fluidd:
     image: cadriel/fluidd:latest

--- a/custom/docker-compose.custom.portainer.yaml
+++ b/custom/docker-compose.custom.portainer.yaml
@@ -81,8 +81,6 @@ services:
   fluidd:
     image: cadriel/fluidd:latest
     restart: unless-stopped
-    profiles:
-      - fluidd
     labels:
       - "traefik.enable=true"
       - "traefik.http.services.fluidd.loadbalancer.server.port=80"


### PR DESCRIPTION
This creates a space for custom configurations that are commonly requested but are not part of the main functionality of prind.
The readme states the intent of these configurations and that support will be limited.

Initially there will be two custom configurations.  

* `docker-compose.custom.multiple-printers.yaml` requested by https://github.com/mkuf/prind/issues/28
* `docker-compose.custom.portainer.yaml` requested by https://github.com/mkuf/prind/issues/39