### PR TITLE
fix klipper image build

### DIFF
--- a/docker/klipper/Dockerfile
+++ b/docker/klipper/Dockerfile
@@ -52,6 +52,9 @@ RUN apt update \
       python3-numpy python3-matplotlib \
  && apt clean
 
+RUN groupadd klipper --gid 1000 \
+ && useradd klipper --uid 1000 --gid klipper
+
 COPY --chown=klipper:klipper --from=build /opt/klipper ./klipper
 COPY --chown=klipper:klipper --from=build /opt/venv ./venv
 
@@ -69,19 +72,15 @@ COPY config.simulavr .config
 RUN make 
 
 WORKDIR /opt
-RUN mkdir run
-RUN groupadd simulavr --gid 1000 \
- && useradd simulavr --uid 1000 --gid simulavr \
- && usermod simulavr --append --groups dialout
 
 RUN git clone git://git.savannah.nongnu.org/simulavr.git \
  && cd simulavr \
  && git checkout release-1.1.0 \
  && make python \
  && make build \
- && chown -R simulavr:simulavr /opt/simulavr
+ && chown -R klipper:klipper /opt/simulavr
 
-USER simulavr
+USER klipper
 ENV PYTHONPATH=/opt/simulavr/build/pysimulavr/
 VOLUME ["/opt/printer_data/run"]
 ENTRYPOINT ["klipper/scripts/avrsim.py"]


### PR DESCRIPTION
When building the klipper image, I received the following error:

```
Step 21/36 : COPY --chown=klipper:klipper --from=build /opt/klipper ./klipper
unable to convert uid/gid chown string to host mapping: can't find uid for user klipper: no such user: klipper
```

The reason is that this stage does not contain the klipper user. I added the required lines to add the user.

This newly added klipper user then conflicts with the simulavr image where the `simulavr` user with the same gid is added. I opted to replace the `simulavr` user with the `klipper` user.

This change is untested.