### PR TITLE
Add ARMv6 Support

### DIFF
--- a/docker/klipper/Dockerfile
+++ b/docker/klipper/Dockerfile
@@ -36,7 +36,7 @@ ENTRYPOINT ["/opt/venv/bin/python", "klipper/klippy/klippy.py"]
 CMD ["-I", "printer_data/run/klipper.tty", "-a", "printer_data/run/klipper.sock", "printer_data/config/printer.cfg"]
 
 ## For building MCU Code
-FROM ubuntu:18.04 as mcu
+FROM debian:bullseye as mcu
 
 WORKDIR /opt
 ARG DEBIAN_FRONTEND=noninteractive
@@ -48,7 +48,7 @@ RUN apt update \
       libusb-dev \
       avrdude gcc-avr binutils-avr avr-libc \
       stm32flash dfu-util libnewlib-arm-none-eabi \
-      gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0 \
+      gcc-arm-none-eabi binutils-arm-none-eabi libusb-1.0-0 \
       python3-numpy python3-matplotlib \
  && apt clean
 

--- a/docker/ustreamer/Dockerfile
+++ b/docker/ustreamer/Dockerfile
@@ -1,5 +1,5 @@
 ## Get Code and make
-FROM debian:buster-slim as build
+FROM debian:bullseye-slim as build
 
 ARG REPO=https://github.com/pikvm/ustreamer
 ARG VERSION=master
@@ -27,13 +27,13 @@ RUN cd ustreamer \
  && make
 
 ## Runtime Image
-FROM debian:buster-slim as run
+FROM debian:bullseye-slim as run
 
 RUN apt update \
  && apt install -y \
       ca-certificates \
-      libevent-2.1 \
-      libevent-pthreads-2.1-6 \
+      libevent-2.1-7 \
+      libevent-pthreads-2.1-7 \
       libjpeg62-turbo \
       libbsd0 \
       libgpiod2 \

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -14,7 +14,7 @@ app=${1}
 registry=${2}
 
 # Set build parameters
-platform="linux/amd64,linux/arm/v7,linux/arm64/v8"
+platform="linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8"
 dockerfile=docker/${app}/Dockerfile
 context=$(echo -n ${dockerfile} | rev | cut -f2- -d'/' | rev)
 


### PR DESCRIPTION
* add linux/arm/v6 platform to build script
* use debian bullseye as base image for klipper mcu target and ustreamer

Fixes https://github.com/mkuf/prind/issues/63