### PR TITLE
fluidd: use docker image from GHCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ With a single Command, you can start up klipper and choose between multiple Fron
 
 Currently supported Frontends:
   * Octoprint (via [Dockerhub](https://hub.docker.com/r/octoprint/octoprint))
-  * Fluidd (via [Dockerhub](https://hub.docker.com/r/cadriel/fluidd))
+  * Fluidd (via [GHCR](https://github.com/fluidd-core/fluidd/pkgs/container/fluidd))
   * Mainsail (via [GHCR](https://github.com/mainsail-crew/mainsail/pkgs/container/mainsail))
   * KlipperScreen
 

--- a/custom/docker-compose.custom.multiple-printers.yaml
+++ b/custom/docker-compose.custom.multiple-printers.yaml
@@ -116,7 +116,7 @@ services:
 
   ## Use Fluidd as Frontend
   fluidd:
-    image: cadriel/fluidd:latest
+    image: ghcr.io/fluidd-core/fluidd:latest
     restart: unless-stopped
     ports:
       - 80:80

--- a/custom/docker-compose.custom.portainer.yaml
+++ b/custom/docker-compose.custom.portainer.yaml
@@ -83,7 +83,7 @@ services:
       traefik.http.routers.webcam.middlewares: webcam
 
   fluidd:
-    image: cadriel/fluidd:latest
+    image: ghcr.io/fluidd-core/fluidd:latest
     restart: unless-stopped
     labels:
       org.prind.service: fluidd

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -100,7 +100,7 @@ services:
       traefik.http.routers.octoprint.entrypoints: web
 
   fluidd:
-    image: cadriel/fluidd:latest
+    image: ghcr.io/fluidd-core/fluidd:latest
     restart: unless-stopped
     profiles:
       - fluidd


### PR DESCRIPTION
The latest official Fluidd Docker image is now only published on GHCR, so I updated the addresses in use.