### PR TITLE
Use bookworm based images for all containers

### DIFF
--- a/docker/klipper/Dockerfile
+++ b/docker/klipper/Dockerfile
@@ -1,6 +1,6 @@
 ## Get Klipper Source and Build venv
 ##
-FROM python:2 as build
+FROM python:3-bookworm as build
 
 ARG REPO=https://github.com/Klipper3d/klipper
 ARG VERSION=master
@@ -12,7 +12,7 @@ RUN git clone ${REPO} klipper \
  && git checkout ${VERSION} \
  && rm -rf .git
 
-RUN virtualenv -p python2 venv \
+RUN python -m venv venv \
  && venv/bin/pip install -r klipper/scripts/klippy-requirements.txt \
  && venv/bin/pip install numpy \
  && venv/bin/python -m compileall klipper/klippy \
@@ -22,7 +22,7 @@ RUN virtualenv -p python2 venv \
 
 ## Klippy Runtime Image
 ##
-FROM python:2-slim as run
+FROM python:3-slim-bookworm as run
 
 WORKDIR /opt
 RUN groupadd klipper --gid 1000 \
@@ -44,14 +44,14 @@ CMD ["-I", "printer_data/run/klipper.tty", "-a", "printer_data/run/klipper.sock"
 
 ## Image for building MCU code including other tooling
 ##
-FROM debian:bullseye as tools
+FROM debian:bookworm as tools
 
 WORKDIR /opt
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update \
  && apt install -y \
       sudo \
-      virtualenv python-dev libffi-dev build-essential pkg-config\
+      virtualenv python3-dev libffi-dev build-essential pkg-config\
       libncurses-dev \
       avrdude gcc-avr binutils-avr avr-libc \
       stm32flash dfu-util libnewlib-arm-none-eabi \
@@ -78,7 +78,7 @@ RUN cd klipper \
 
 ## Runtime image for the klipper_mcu binary
 ##
-FROM debian:bullseye-slim as hostmcu
+FROM debian:bookworm-slim as hostmcu
 
 RUN apt update \
  && apt install -y gpiod \

--- a/docker/klipperscreen/Dockerfile
+++ b/docker/klipperscreen/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3 as build
+FROM python:3-bookworm as build
 
 ARG REPO=https://github.com/jordanruthe/KlipperScreen
 ARG VERSION=master
@@ -18,7 +18,7 @@ RUN git clone ${REPO} klipperscreen \
 RUN python -m venv venv \
  && venv/bin/pip install -r klipperscreen/scripts/KlipperScreen-requirements.txt
 
-FROM python:3-slim as run
+FROM python:3-slim-bookworm as run
 
 RUN apt update \
  && apt install -y \

--- a/docker/moonraker/Dockerfile
+++ b/docker/moonraker/Dockerfile
@@ -1,5 +1,5 @@
 ## Get Code and Build venv
-FROM python:3-bullseye as build
+FROM python:3-bookworm as build
 
 ARG REPO=https://github.com/Arksine/moonraker
 ARG VERSION=master
@@ -15,7 +15,7 @@ RUN python -m venv venv \
  && venv/bin/pip install -r moonraker/scripts/moonraker-requirements.txt
 
 ## Runtime Image
-FROM python:3-slim-bullseye as run
+FROM python:3-slim-bookworm as run
 
 RUN apt update \
  && apt install -y \
@@ -23,11 +23,11 @@ RUN apt update \
       python3-libgpiod \
       curl \
       libcurl4 \
-      libssl1.1 \
+      libssl3 \
       liblmdb0 \
       libsodium23 \
       libjpeg62-turbo \
-      libtiff5 \
+      libtiff6 \
       libxcb1 \
       zlib1g \
       iproute2 \

--- a/docker/ustreamer/Dockerfile
+++ b/docker/ustreamer/Dockerfile
@@ -1,5 +1,5 @@
 ## Get Code and make
-FROM debian:bullseye-slim as build
+FROM debian:bookworm-slim as build
 
 ARG REPO=https://github.com/pikvm/ustreamer
 ARG VERSION=master
@@ -27,7 +27,7 @@ RUN cd ustreamer \
  && make
 
 ## Runtime Image
-FROM debian:bullseye-slim as run
+FROM debian:bookworm-slim as run
 
 RUN apt update \
  && apt install -y \


### PR DESCRIPTION
Debian bookworm has recently been released.  
The `python:3` base images already upgraded from bullseye to bookworm, breaking the moonraker build in the process. 

The goal is to explicitly use bookworm based images where possible. 
e.g.
* `python:3-bookworm`
* `python:3-slim-bookworm`
* `debian:bookworm`

In the process of this, klipper images will be upgraded to Python 3

