### PR TITLE
Add moonraker-obico service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 <!--
 ## [Unreleased]
 ### Added
+- profile: moonraker-obico via #89
 ### Fixed
 ### Changed
 - docker: update repo url for KlipperScreen

--- a/README.md
+++ b/README.md
@@ -154,6 +154,29 @@ The default configuration provided with this repository contains everything need
 docker compose --profile mainsail --profile mobileraker_companion up -d
 ```
 
+#### moonraker-obico
+> This profile is incompatible with OctoPrint, choose Fluidd or Mainsail instead.
+
+1. Link a new `Klipper`-Type Printer via the Webinterface
+2. Klick `Next` when prompted to *Install Obico for Klipper*, not executing the shown Commands
+3. Change to the root of the prind repository and start the linking process
+```bash
+cd prind
+
+docker run --rm -it \
+  -v $(pwd)/config:/opt/printer_data/config \
+  --entrypoint /opt/venv/bin/python \
+  ghcr.io/thespaghettidetective/moonraker-obico:latest \
+    -m moonraker_obico.link -c /opt/printer_data/config/moonraker-obico.cfg
+```
+4. Enter the *6-digit verification code*
+5. Check if `[server].auth_token` is set in `config/mooonraker-obico.cfg`, see the [Official Documentation](https://www.obico.io/docs/user-guides/moonraker-obico/config/) on further configuration Options
+6. Start the stack
+```bash
+docker compose --profile mainsail --profile moonraker-obico up -d
+```
+
+
 ## Updating
 Images are built daily and tagged with latest and the first seven chars of the commit-sha of the remote repo. 
 Example: 

--- a/README.md
+++ b/README.md
@@ -157,14 +157,23 @@ docker compose --profile mainsail --profile mobileraker_companion up -d
 #### moonraker-obico
 > This profile is incompatible with OctoPrint, choose Fluidd or Mainsail instead.
 
-1. Link a new `Klipper`-Type Printer via the Webinterface
+[moonraker-obico by TheSpaghettiDetective](https://github.com/TheSpaghettiDetective/moonraker-obico) can be enabled via the `moonraker-obico` Profile.  
+
+The default configuration provided with this repository contains everything needed to access the webcam and use the tunnel with obico Cloud. This requires an account at https://obico.io.  
+If you use a self hosted instance of [obico-server](https://github.com/TheSpaghettiDetective/obico-server), you'll have to change the `[server].url` at `config/moonraker-obico.cfg`.  
+
+For further configuration options, see the [Official Documentation](https://www.obico.io/docs/user-guides/moonraker-obico/config/).
+
+Follow these steps to link your printer and start the profile:
+
+1. Add a new `Klipper`-Type Printer via the Webinterface
 2. Klick `Next` when prompted to *Install Obico for Klipper*, not executing the shown Commands
 3. Change to the root of the prind repository and start the linking process
 ```bash
 docker compose -f docker-compose.extra.link-obico.yaml run --rm link-obico
 ```
 4. Enter the *6-digit verification code*
-5. Check if `[server].auth_token` is set in `config/mooonraker-obico.cfg`, see the [Official Documentation](https://www.obico.io/docs/user-guides/moonraker-obico/config/) on further configuration Options
+5. Check if `[server].auth_token` is set in `config/mooonraker-obico.cfg`
 6. Start the stack
 ```bash
 docker compose --profile mainsail --profile moonraker-obico up -d

--- a/README.md
+++ b/README.md
@@ -161,13 +161,7 @@ docker compose --profile mainsail --profile mobileraker_companion up -d
 2. Klick `Next` when prompted to *Install Obico for Klipper*, not executing the shown Commands
 3. Change to the root of the prind repository and start the linking process
 ```bash
-cd prind
-
-docker run --rm -it \
-  -v $(pwd)/config:/opt/printer_data/config \
-  --entrypoint /opt/venv/bin/python \
-  ghcr.io/thespaghettidetective/moonraker-obico:latest \
-    -m moonraker_obico.link -c /opt/printer_data/config/moonraker-obico.cfg
+docker compose -f docker-compose.extra.link-obico.yaml run --rm link-obico
 ```
 4. Enter the *6-digit verification code*
 5. Check if `[server].auth_token` is set in `config/mooonraker-obico.cfg`, see the [Official Documentation](https://www.obico.io/docs/user-guides/moonraker-obico/config/) on further configuration Options

--- a/config/moonraker-obico.cfg
+++ b/config/moonraker-obico.cfg
@@ -1,0 +1,21 @@
+[server]
+url = https://app.obico.io
+auth_token = 
+
+[moonraker]
+host = moonraker
+port = 7125
+
+[webcam]
+disable_video_streaming = False
+snapshot_url = http://webcam:8080/snapshot
+stream_url = http://webcam:8080/stream
+
+[logging]
+path = /opt/printer_data/logs/moonraker-obico.log
+level = INFO
+
+[tunnel]
+dest_host = traefik
+dest_port = 80
+dest_is_ssl = False

--- a/docker-compose.extra.link-obico.yaml
+++ b/docker-compose.extra.link-obico.yaml
@@ -1,0 +1,7 @@
+services:
+  link-obico:
+    image: ghcr.io/thespaghettidetective/moonraker-obico:latest
+    entrypoint: /opt/venv/bin/python
+    command: ["-m", "moonraker_obico.link", "-c", "/opt/printer_data/config/moonraker-obico.cfg"]
+    volumes:
+      - ./config:/opt/printer_data/config

--- a/docker-compose.extra.link-obico.yaml
+++ b/docker-compose.extra.link-obico.yaml
@@ -1,6 +1,7 @@
 services:
   link-obico:
     image: ghcr.io/thespaghettidetective/moonraker-obico:latest
+    user: 0:0
     entrypoint: /opt/venv/bin/python
     command: ["-m", "moonraker_obico.link", "-c", "/opt/printer_data/config/moonraker-obico.cfg"]
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -158,6 +158,17 @@ services:
     labels:
       org.prind.service: hostmcu
 
+  moonraker-obico:
+    image: ghcr.io/thespaghettidetective/moonraker-obico:latest
+    restart: unless-stopped
+    volumes:
+      - ./config:/opt/printer_data/config
+      - log:/opt/printer_data/logs
+    profiles:
+      - moonraker-obico
+    labels:
+      org.prind.service: moonraker-obico
+
   ## Accompanying Services/Infra
   ##
 


### PR DESCRIPTION
moonraker-obico was requested in https://github.com/mkuf/prind/issues/88.

This adds the moonraker-obico service, a base configuration file and documentation. 

May be merged, when https://github.com/TheSpaghettiDetective/moonraker-obico/pull/74 has been accepted.