### PR TITLE
Add Spoolman Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 <!--
 ## [Unreleased]
 ### Added
+- profile: spoolman
 ### Fixed
 ### Changed
 ### Removed

--- a/README.md
+++ b/README.md
@@ -176,6 +176,15 @@ docker compose -f docker-compose.extra.link-obico.yaml run --rm link-obico
 docker compose --profile mainsail --profile moonraker-obico up -d
 ```
 
+#### Spoolman
+[Spoolman by Donkie](https://github.com/Donkie/Spoolman) can be enabled via the `spoolman` Profile.  
+
+After starting the stack via 
+```bash
+docker compose --profile fluidd --profile spoolman up -d
+```
+
+Navigate to http://<yourprinter>/spoolman to access the spoolman webinterface.
 
 ## Updating
 Images are built daily and tagged with `latest` and the [git description](https://git-scm.com/docs/git-describe#_examples) of the remote repo. 

--- a/README.md
+++ b/README.md
@@ -179,12 +179,13 @@ docker compose --profile mainsail --profile moonraker-obico up -d
 #### Spoolman
 [Spoolman by Donkie](https://github.com/Donkie/Spoolman) can be enabled via the `spoolman` Profile.  
 
-After starting the stack via 
+Uncomment the spoolman section in `moonraker.conf` and add your printers Hostname or IP to the server URL.  
+The stack can then be started by specifying the `spoolman` profile. 
 ```bash
 docker compose --profile fluidd --profile spoolman up -d
 ```
 
-Navigate to http://<yourprinter>/spoolman to access the spoolman webinterface.
+Navigate to `http://<yourprinter>:8000` to access the spool manager webinterface.
 
 ## Updating
 Images are built daily and tagged with `latest` and the [git description](https://git-scm.com/docs/git-describe#_examples) of the remote repo. 

--- a/config/moonraker.conf
+++ b/config/moonraker.conf
@@ -16,3 +16,6 @@ cors_domains:
 [octoprint_compat]
 
 [history]
+
+[spoolman]
+server: http://spoolman:8000/spoolman

--- a/config/moonraker.conf
+++ b/config/moonraker.conf
@@ -16,6 +16,3 @@ cors_domains:
 [octoprint_compat]
 
 [history]
-
-[spoolman]
-server: http://spoolman:8000/spoolman

--- a/config/moonraker.conf
+++ b/config/moonraker.conf
@@ -16,3 +16,9 @@ cors_domains:
 [octoprint_compat]
 
 [history]
+
+## Uncomment the following lines if the stack is started with the spoolman profile.
+## Add your printers IP address or hostname to the server url.
+#
+# [spoolman]
+# server: http://<yourprinter>:8000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -176,21 +176,16 @@ services:
       org.prind.service: moonraker-obico
 
   spoolman:
-    image: ghcr.io/donkie/spoolman:edge
+    image: ghcr.io/donkie/spoolman:latest
     restart: unless-stopped
-    command: ["--host", "0.0.0.0", "--port", "8000", "--root-path", "/spoolman"]
     volumes:
       - spoolman-db:/home/app/.local/share/spoolman
     profiles:
       - spoolman
+    ports:
+      - 8000:8000
     labels:
       org.prind.service: spoolman
-      traefik.enable: true
-      traefik.http.services.spoolman.loadbalancer.server.port: 8000
-      traefik.http.routers.spoolman.entrypoints: web
-      traefik.http.routers.spoolman.rule: PathPrefix(`/spoolman`)
-      traefik.http.routers.spoolman.middlewares: strip-spoolman@docker
-      traefik.http.middlewares.strip-spoolman.stripprefix.prefixes: /spoolman
 
   ## Accompanying Services/Infra
   ##

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -175,6 +175,23 @@ services:
     labels:
       org.prind.service: moonraker-obico
 
+  spoolman:
+    image: ghcr.io/donkie/spoolman:edge
+    restart: unless-stopped
+    command: ["--host", "0.0.0.0", "--port", "8000", "--root-path", "/spoolman"]
+    volumes:
+      - spoolman-db:/home/app/.local/share/spoolman
+    profiles:
+      - spoolman
+    labels:
+      org.prind.service: spoolman
+      traefik.enable: true
+      traefik.http.services.spoolman.loadbalancer.server.port: 8000
+      traefik.http.routers.spoolman.entrypoints: web
+      traefik.http.routers.spoolman.rule: PathPrefix(`/spoolman`)
+      traefik.http.routers.spoolman.middlewares: strip-spoolman@docker
+      traefik.http.middlewares.strip-spoolman.stripprefix.prefixes: /spoolman
+
   ## Accompanying Services/Infra
   ##
 
@@ -216,3 +233,4 @@ volumes:
     driver_opts:
       type: tmpfs
       device: tmpfs
+  spoolman-db:


### PR DESCRIPTION
This adds https://github.com/Donkie/Spoolman as service.  

Needs: 
* https://github.com/Donkie/Spoolman/pull/94
* ~~https://github.com/Donkie/Spoolman/issues/95~~

Service will open port 8000 on the host and is not proxied via traefik, due to spoolman not supporting subpath hosting at the moment. 
