### PR TITLE
Move config from mount to volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM busybox:latest
 
 COPY config /opt/printer_data/config
+COPY config/octoprint.yaml /octoprint/octoprint/config.yaml
 RUN chown -R 1000:1000 /opt/printer_data/config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM busybox:latest
+
+COPY config /opt/printer_data/config
+RUN chown -R 1000:1000 /opt/printer_data/config

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -177,10 +177,10 @@ services:
   ## Config dir needs to be writable by uid/gid 1000
   ## This container sets the right permissions and exits
   init:
-    image: busybox:latest
-    command: chown -R 1000:1000 /prind/config
+    build: docker/init
     volumes:
       - .:/prind
+      - config:/opt/printer_data/config
     labels:
       org.prind.service: init
 
@@ -201,14 +201,15 @@ services:
       org.prind.service: traefik
 
 volumes:
-  run:
+  config:
+  gcode:
+  moonraker-db:
+  log:
     driver_opts:
       type: tmpfs
       device: tmpfs
-  gcode:
   octoprint:
-  moonraker-db:
-  log:
+  run:
     driver_opts:
       type: tmpfs
       device: tmpfs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
     command: -I printer_data/run/klipper.tty -a printer_data/run/klipper.sock printer_data/config/printer.cfg -l printer_data/logs/klippy.log
     volumes:
       - /dev:/dev
-      - ./config:/opt/printer_data/config
+      - config:/opt/printer_data/config
       - run:/opt/printer_data/run
       - gcode:/opt/printer_data/gcodes
       - log:/opt/printer_data/logs
@@ -44,7 +44,7 @@ services:
       - gcode:/opt/printer_data/gcodes
       - log:/opt/printer_data/logs
       - moonraker-db:/opt/printer_data/database
-      - ./config:/opt/printer_data/config
+      - config:/opt/printer_data/config
     profiles:
       - fluidd
       - mainsail
@@ -119,7 +119,7 @@ services:
       - /run/systemd:/run/systemd
       - /etc/localtime:/etc/localtime:ro
       - /tmp/.X11-unix:/tmp/.X11-unix
-      - ./config:/opt/cfg
+      - config:/opt/cfg
     labels:
       org.prind.service: klipperscreen
 
@@ -133,7 +133,7 @@ services:
     volumes:
       - gcode:/opt/printer_data/gcodes
       - log:/opt/printer_data/logs
-      - ./config:/opt/printer_data/config
+      - config:/opt/printer_data/config
     labels:
       org.prind.service: moonraker-telegram-bot
 
@@ -143,7 +143,7 @@ services:
     profiles:
       - mobileraker_companion
     volumes:
-      - ./config:/opt/printer_data/config
+      - config:/opt/printer_data/config
     labels:
       org.prind.service: mobileraker_companion
 
@@ -164,7 +164,7 @@ services:
     restart: unless-stopped
     privileged: true
     volumes:
-      - ./config:/opt/printer_data/config
+      - config:/opt/printer_data/config
       - log:/opt/printer_data/logs
     profiles:
       - moonraker-obico
@@ -177,9 +177,8 @@ services:
   ## Config dir needs to be writable by uid/gid 1000
   ## This container sets the right permissions and exits
   init:
-    build: docker/init
+    build: .
     volumes:
-      - .:/prind
       - config:/opt/printer_data/config
     labels:
       org.prind.service: init

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
       - run:/opt/printer_data/run
       - gcode:/opt/printer_data/gcodes
       - log:/opt/printer_data/logs
+    network_mode: host
     labels:
       org.prind.service: klipper
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -71,7 +71,6 @@ services:
       - /dev:/dev
       - run:/opt/printer_data/run
       - octoprint:/octoprint
-      - ./config/octoprint.yaml:/octoprint/octoprint/config.yaml
     profiles:
       - octoprint
     labels:
@@ -180,6 +179,7 @@ services:
     build: .
     volumes:
       - config:/opt/printer_data/config
+      - octoprint:/octoprint
     labels:
       org.prind.service: init
 

--- a/docker/init/Dockerfile
+++ b/docker/init/Dockerfile
@@ -1,5 +1,0 @@
-FROM busybox:latest
-
-RUN mkdir -p /opt/printer_data/config
-RUN cp -R /prind/config /opt/printer_data/config
-RUN chown -R 1000:1000 /opt/printer_data/config

--- a/docker/init/Dockerfile
+++ b/docker/init/Dockerfile
@@ -1,0 +1,5 @@
+FROM busybox:latest
+
+RUN mkdir -p /opt/printer_data/config
+RUN cp -R /prind/config /opt/printer_data/config
+RUN chown -R 1000:1000 /opt/printer_data/config


### PR DESCRIPTION
# Move config from mount to volume

## Motivation
- Easier deployment with Portainer

## How it was tested
1. 
    ```bash
    docker compose --profile hostmcu --profile fluidd --profile mobileraker_companion up -d
    ```
2. 
    ```bash
    COMPOSE_PROFILES=hostmcu,fluidd,mobileraker_companion docker compose up -d
    ```
3. Launch stack in Portainer with environment variable `COMPOSE_PROFILES=hostmcu,fluidd,mobileraker_companion`.