### PR TITLE
fix: Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ out
 *.bkp
 resonances
 *.tar.gz
+*.zip
+config/printer-*.cfg


### PR DESCRIPTION
This adds a git exceptions to `zip` files and klipper config files with the `config` directory that are generated when running prind.