### PR TITLE
run individual build jobs for each platform

### DIFF
--- a/.github/workflows/image-build-review.yaml
+++ b/.github/workflows/image-build-review.yaml
@@ -41,6 +41,11 @@ jobs:
     strategy:
       matrix:
         app: ${{ fromJSON(needs.changes.outputs.apps) }}
+        platform:
+          - linux/amd64
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/arm64/v8
     runs-on: ubuntu-latest
     steps:
       - name: "[prind] checkout"
@@ -51,8 +56,5 @@ jobs:
         run: |
           python3 scripts/build/build.py ${{ matrix.app }} \
             --backfill 0 \
-            --platform linux/amd64 \
-            --platform linux/arm/v6 \
-            --platform linux/arm/v7 \
-            --platform linux/arm64/v8 \
+            --platform ${{ matrix.platform }} \
             --force


### PR DESCRIPTION
This adds a matrix list to spawn a job for each target platform of each app.  
This decreases overall workflow runtime from average 2.5h to 1h. 