### PR TITLE
moonraker: add git to runtime image

### DIFF
--- a/docker/moonraker/Dockerfile
+++ b/docker/moonraker/Dockerfile
@@ -33,6 +33,7 @@ RUN apt update \
       iproute2 \
       systemd \
       sudo \
+      git \
  && apt clean
 
 WORKDIR /opt


### PR DESCRIPTION
Adds gut to the runtime Image of Moonraker to allow update manager to be used. 

Fixes #138 