### PR TITLE
klipper: add setuptools to venv

### DIFF
--- a/docker/klipper/requirements-prind.txt
+++ b/docker/klipper/requirements-prind.txt
@@ -1,1 +1,8 @@
+## This file contains additional requirements
+## Packages defined here will be installed prior to klippy requirements
+## 
 numpy==1.26.4
+# this is a workaround as setuptools is no longer installed in venvs since python 3.12
+# klippy is installing python-can==3.3.4 which requires setuptools to be present
+# May be removed if python-can has been upgraded upstream in https://github.com/Klipper3d/klipper/pull/6557.
+setuptools


### PR DESCRIPTION
This adds setuptools w/o any version pinning to the docker image to get python-can 3.3.4 working in python 3.12