### PR TITLE
klipper: revert base image to python 3.11

### DIFF
--- a/docker/klipper/Dockerfile
+++ b/docker/klipper/Dockerfile
@@ -1,6 +1,6 @@
 ## Get Klipper Source and Build venv
 ##
-FROM python:3.12-bookworm as build
+FROM python:3.11-bookworm as build
 
 RUN apt update \
  && apt install -y cmake \
@@ -28,7 +28,7 @@ RUN venv/bin/pip install -r klipper/scripts/klippy-requirements.txt \
 
 ## Klippy Runtime Image
 ##
-FROM python:3.12-slim-bookworm as run
+FROM python:3.11-slim-bookworm as run
 
 WORKDIR /opt
 RUN groupadd klipper --gid 1000 \

--- a/docker/klipper/requirements-prind.txt
+++ b/docker/klipper/requirements-prind.txt
@@ -1,8 +1,4 @@
 ## This file contains additional requirements
 ## Packages defined here will be installed prior to klippy requirements
 ## 
-numpy==1.26.4
-# this is a workaround as setuptools is no longer installed in venvs since python 3.12
-# klippy is installing python-can==3.3.4 which requires setuptools to be present
-# May be removed if python-can has been upgraded upstream in https://github.com/Klipper3d/klipper/pull/6557.
-setuptools
+numpy


### PR DESCRIPTION
The upgrade to python 3.12 base images introduced w/ https://github.com/mkuf/prind/pull/125 is causing issues for klipper.  
These changes will therefore be reverted to allow for stable operation of klipper. 

fixes: https://github.com/mkuf/prind/issues/150
fixes: https://github.com/mkuf/prind/issues/143