### PR TITLE
klipperscreen: add libsystemd-dev to build stage

### DIFF
--- a/docker/klipperscreen/Dockerfile
+++ b/docker/klipperscreen/Dockerfile
@@ -8,6 +8,7 @@ RUN apt update \
       libgirepository1.0-dev \
       libdbus-glib-1-dev \
       cmake \
+      libsystemd-dev \
  && apt clean
 
 WORKDIR /opt


### PR DESCRIPTION
Build job for klipperscreen is failing with an error.

```
2024-05-25 02:34:47,732 - prind - INFO - BUILD: #38 130.3       subprocess.CalledProcessError: Command '('pkg-config', '--modversion', 'libsystemd')' returned non-zero exit status 1.
```
_via https://github.com/mkuf/prind/actions/runs/9232248885/job/25406187605#step:5:5639_

Adding `libsystemd-dev` to the build stage of the Dockerfile should fix this. 