### PR TITLE
ci: fix broken pip install on ubuntu-24.04 runner

### DIFF
--- a/.github/actions/image-build-common/action.yaml
+++ b/.github/actions/image-build-common/action.yaml
@@ -35,6 +35,6 @@ runs:
     - name: "[prind] install requirements"
       shell: bash
       run: |
-      python3 -m venv venv
-      source venv/bin/activate
-      pip install -r scripts/build/requirements.txt
+        python3 -m venv venv
+        source venv/bin/activate
+        pip install -r scripts/build/requirements.txt

--- a/.github/actions/image-build-common/action.yaml
+++ b/.github/actions/image-build-common/action.yaml
@@ -34,4 +34,7 @@ runs:
 
     - name: "[prind] install requirements"
       shell: bash
-      run: pip install -r scripts/build/requirements.txt
+      run: |
+      python3 -m venv venv
+      source venv/bin/activate
+      pip install -r scripts/build/requirements.txt

--- a/.github/actions/image-build-common/action.yaml
+++ b/.github/actions/image-build-common/action.yaml
@@ -38,3 +38,4 @@ runs:
         python3 -m venv venv
         source venv/bin/activate
         pip install -r scripts/build/requirements.txt
+        echo PATH=$PATH >> $GITHUB_ENV


### PR DESCRIPTION
With the build image being updated to ubuntu 24.04, python dependencies for the build script can't be installed on the runner directly. 

This PR sets up a python venv to install build dependencies in the prepare phase. 