### PR TITLE
CI: use ubuntu 22.04 for build jobs

### DIFF
--- a/.github/workflows/image-build-and-publish-push.yaml
+++ b/.github/workflows/image-build-and-publish-push.yaml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         app: ${{ fromJSON(needs.changes.outputs.apps) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: "[prind] checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/image-build-and-publish-schedule.yaml
+++ b/.github/workflows/image-build-and-publish-schedule.yaml
@@ -12,7 +12,7 @@ jobs:
           - klipperscreen
           - moonraker
           - ustreamer
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: "[prind] checkout"
         uses: actions/checkout@v4

--- a/.github/workflows/image-build-review.yaml
+++ b/.github/workflows/image-build-review.yaml
@@ -54,7 +54,7 @@ jobs:
           - linux/arm/v6
           - linux/arm/v7
           - linux/arm64/v8
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: "[prind] checkout"
         uses: actions/checkout@v4


### PR DESCRIPTION
Explicitly uses the ubuntu 22.04 runner image for build jobs to work around segmentation faults in arm64 builds on ubuntu 24.04.

Job log: https://github.com/mkuf/prind/actions/runs/13170811025/job/36760716572  
Upstream issue: https://github.com/actions/runner-images/issues/11471