### PR TITLE
klipper: add -O2 to CXXFLAGS so simulavr builds optimised

### DIFF
--- a/docker/klipper/Dockerfile
+++ b/docker/klipper/Dockerfile
@@ -2,7 +2,7 @@
 ##
 FROM python:3.12-trixie AS build
 
-ENV CXXFLAGS="-Wno-error"
+ENV CXXFLAGS="-O2 -Wno-error"
 
 RUN apt update \
  && apt install -y cmake \


### PR DESCRIPTION
CXXFLAGS env variable replaces compilers default optimization flags. This commit adds an explicit optimization flag. Note that this will also propagate all compiled package, but it should not produce any unwanted effects.

This helps increase the performance by as much as 7x on a machine that was unable to use simulavr out of the box.

Closes #284