### PR TITLE
klipper: overwrite cxxflags for prind-requirements only

### DIFF
--- a/docker/klipper/Dockerfile
+++ b/docker/klipper/Dockerfile
@@ -2,8 +2,6 @@
 ##
 FROM python:3.12-trixie AS build
 
-ENV CXXFLAGS="-Wno-error"
-
 RUN apt update \
  && apt install -y cmake \
  && apt clean
@@ -68,7 +66,7 @@ RUN apt update \
  && apt clean
 
 COPY requirements-prind-tools.txt .
-RUN venv/bin/pip install -r requirements-prind-tools.txt
+RUN CXXFLAGS="-Wno-error" venv/bin/pip install -r requirements-prind-tools.txt
 
 RUN ln -s /opt/venv /root/klippy-env
 ENV PATH=/opt/venv/bin:$PATH


### PR DESCRIPTION
limit impact of overwriting cxxflags to pip installation of prind-requirements only.

From https://github.com/mkuf/prind/issues/284